### PR TITLE
chore(deps): drop thecodingmachine/safe v2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/contracts": "^3.0",
         "symfony/dependency-injection": "^7.0 || ^8.0",
         "symfony/framework-bundle": "^7.0 || ^8.0",
-        "thecodingmachine/safe": "^2 || ^3"
+        "thecodingmachine/safe": "^3"
     },
     "require-dev": {
         "doctrine/coding-standard": "^14.0",


### PR DESCRIPTION
## Summary
- Require thecodingmachine/safe ^3, dropping v2 support