### PR TITLE
chore(deps): remove thecodingmachine/safe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "symfony/console": "^7.4 || ^8.0",
         "symfony/contracts": "^3.0",
         "symfony/dependency-injection": "^7.4 || ^8.0",
-        "symfony/framework-bundle": "^7.4 || ^8.0",
-        "thecodingmachine/safe": "^3"
+        "symfony/framework-bundle": "^7.4 || ^8.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^14.0",
@@ -35,8 +34,7 @@
         "phpstan/phpstan-phpunit": "^2.0.0",
         "phpstan/phpstan-strict-rules": "^2.0.0",
         "phpunit/phpunit": "^13.0",
-        "symfony/yaml": "^7.4 || ^8.0",
-        "thecodingmachine/phpstan-safe-rule": "^1.0"
+        "symfony/yaml": "^7.4 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Kafka/Configuration.php
+++ b/src/Kafka/Configuration.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\KafkaBundle\Kafka;
 
-use function Safe\gethostname;
+use function gethostname;
 use function sprintf;
 
 final class Configuration
@@ -31,11 +31,16 @@ final class Configuration
 
     public function getClientIdWithHostname(): string
     {
-        $clientId = $this->config['client']['id'] ?? null;
-        if ($clientId === null) {
-            return gethostname();
+        $hostname = gethostname();
+        if ($hostname === false) {
+            $hostname = 'unknown';
         }
 
-        return sprintf('%s-%s', $clientId, gethostname());
+        $clientId = $this->config['client']['id'] ?? null;
+        if ($clientId === null) {
+            return $hostname;
+        }
+
+        return sprintf('%s-%s', $clientId, $hostname);
     }
 }

--- a/tests/KafkaTestCase.php
+++ b/tests/KafkaTestCase.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Yaml\Yaml;
-use function Safe\file_get_contents;
+use function file_get_contents;
 use function sys_get_temp_dir;
 
 abstract class KafkaTestCase extends TestCase
@@ -29,6 +29,7 @@ abstract class KafkaTestCase extends TestCase
         $container->registerExtension($extension);
 
         $fileContents = file_get_contents(sprintf('%s/%s.yaml', __DIR__, $configName));
+        self::assertIsString($fileContents);
 
         $configs = Yaml::parse($fileContents);
         assert(is_array($configs));


### PR DESCRIPTION
## Summary
- Remove `thecodingmachine/safe` and `thecodingmachine/phpstan-safe-rule` dependencies
- Replace `Safe\gethostname` and `Safe\file_get_contents` with native PHP functions

## Impact
- `gethostname()` and `file_get_contents()` now return `string|false` instead of throwing — callers that rely on exceptions for control flow would need adjustment, but neither call site does