### PR TITLE
Increase minimum Symfony version to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     "require": {
         "php": "^8.4",
         "simpod/kafka": "^0.3 || ^0.4",
-        "symfony/config": "^7.0 || ^8.0",
-        "symfony/console": "^7.0 || ^8.0",
+        "symfony/config": "^7.4 || ^8.0",
+        "symfony/console": "^7.4 || ^8.0",
         "symfony/contracts": "^3.0",
-        "symfony/dependency-injection": "^7.0 || ^8.0",
-        "symfony/framework-bundle": "^7.0 || ^8.0",
+        "symfony/dependency-injection": "^7.4 || ^8.0",
+        "symfony/framework-bundle": "^7.4 || ^8.0",
         "thecodingmachine/safe": "^3"
     },
     "require-dev": {
@@ -35,7 +35,7 @@
         "phpstan/phpstan-phpunit": "^2.0.0",
         "phpstan/phpstan-strict-rules": "^2.0.0",
         "phpunit/phpunit": "^13.0",
-        "symfony/yaml": "^7.0 || ^8.0",
+        "symfony/yaml": "^7.4 || ^8.0",
         "thecodingmachine/phpstan-safe-rule": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
## Summary
- Bumped minimum Symfony version constraint from `^7.0` to `^7.4` for all Symfony packages (`config`, `console`, `dependency-injection`, `framework-bundle`, `yaml`)

## Test plan
- [ ] Verify CI passes with Symfony 7.4+
- [ ] Verify compatibility with Symfony 8.0 is unaffected

https://claude.ai/code/session_01RphBDSoFGabv1Qg4x44MfZ