### PR TITLE
Disable Composer lock file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
             "phpstan/extension-installer": true,
             "infection/extension-installer": true
         },
+        "lock": false,
         "sort-packages": true
     },
     "require": {


### PR DESCRIPTION
## Summary
- Disable Composer lock file generation for this library by setting `config.lock` to `false`.
- Keeps dependency resolution flexible for consumers while preserving normal Composer metadata.